### PR TITLE
kill threads on restore

### DIFF
--- a/include/afl_snapshot.h
+++ b/include/afl_snapshot.h
@@ -7,24 +7,26 @@
 
 #define AFL_SNAPSHOT_IOCTL_MAGIC 44313
 
-#define AFL_SNAPSHOT_IOCTL_DO        _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 1)
-#define AFL_SNAPSHOT_IOCTL_CLEAN     _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 2)
-#define AFL_SNAPSHOT_EXCLUDE_VMRANGE _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 3, struct afl_snapshot_vmrange_args*)
-#define AFL_SNAPSHOT_INCLUDE_VMRANGE _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 4, struct afl_snapshot_vmrange_args*)
-#define AFL_SNAPSHOT_IOCTL_TAKE      _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 5, int)
-#define AFL_SNAPSHOT_IOCTL_RESTORE   _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 6)
+#define AFL_SNAPSHOT_IOCTL_DO _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 1)
+#define AFL_SNAPSHOT_IOCTL_CLEAN _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 2)
+#define AFL_SNAPSHOT_EXCLUDE_VMRANGE \
+  _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 3, struct afl_snapshot_vmrange_args *)
+#define AFL_SNAPSHOT_INCLUDE_VMRANGE \
+  _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 4, struct afl_snapshot_vmrange_args *)
+#define AFL_SNAPSHOT_IOCTL_TAKE _IOR(AFL_SNAPSHOT_IOCTL_MAGIC, 5, int)
+#define AFL_SNAPSHOT_IOCTL_RESTORE _IO(AFL_SNAPSHOT_IOCTL_MAGIC, 6)
 
 // Trace new mmaped ares and unmap them on restore.
-#define AFL_SNAPSHOT_MMAP  1
+#define AFL_SNAPSHOT_MMAP 1
 // Do not snapshot any page (by default all writeable not-shared pages
 // are shanpshotted.
 #define AFL_SNAPSHOT_BLOCK 2
 // Snapshot file descriptor state, close newly opened descriptors
-#define AFL_SNAPSHOT_FDS   4
+#define AFL_SNAPSHOT_FDS 4
 // Snapshot registers state
-#define AFL_SNAPSHOT_REGS  8
+#define AFL_SNAPSHOT_REGS 8
 // Perform a restore when exit_group is invoked
-#define AFL_SNAPSHOT_EXIT  16
+#define AFL_SNAPSHOT_EXIT 16
 // TODO(andrea) allow not COW snapshots (high perf on small processes)
 // Disable COW, restore all the snapshotted pages
 #define AFL_SNAPSHOT_NOCOW 32

--- a/include/libaflsnapshot.h
+++ b/include/libaflsnapshot.h
@@ -3,11 +3,11 @@
 
 #include "afl_snapshot.h"
 
-int afl_snapshot_init();
-void afl_snapshot_exclude_vmrange(void* start, void* end);
-void afl_snapshot_include_vmrange(void* start, void* end);
-int afl_snapshot_do(void);
-int afl_snapshot_take(int config);
+int  afl_snapshot_init();
+void afl_snapshot_exclude_vmrange(void *start, void *end);
+void afl_snapshot_include_vmrange(void *start, void *end);
+int  afl_snapshot_do(void);
+int  afl_snapshot_take(int config);
 void afl_snapshot_restore(void);
 void afl_snapshot_clean(void);
 

--- a/lib/libaflsnapshot.c
+++ b/lib/libaflsnapshot.c
@@ -13,16 +13,18 @@ int afl_snapshot_init() {
 
 }
 
-void afl_snapshot_exclude_vmrange(void* start, void* end) {
+void afl_snapshot_exclude_vmrange(void *start, void *end) {
 
-  struct afl_snapshot_vmrange_args args = {(unsigned long)start, (unsigned long)end};
+  struct afl_snapshot_vmrange_args args = {(unsigned long)start,
+                                           (unsigned long)end};
   ioctl(dev_fd, AFL_SNAPSHOT_EXCLUDE_VMRANGE, &args);
 
 }
 
-void afl_snapshot_include_vmrange(void* start, void* end) {
+void afl_snapshot_include_vmrange(void *start, void *end) {
 
-  struct afl_snapshot_vmrange_args args = {(unsigned long)start, (unsigned long)end};
+  struct afl_snapshot_vmrange_args args = {(unsigned long)start,
+                                           (unsigned long)end};
   ioctl(dev_fd, AFL_SNAPSHOT_INCLUDE_VMRANGE, &args);
 
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ override M = $(PWD)
 endif
 
 obj-m += afl_snapshot.o
-afl_snapshot-objs := memory.o files.o task_data.o snapshot.o hook.o module.o
+afl_snapshot-objs := memory.o files.o threads.o task_data.o snapshot.o hook.o module.o
 
 ccflags-y := \
   -ggdb3 \

--- a/src/files.c
+++ b/src/files.c
@@ -3,7 +3,7 @@
 #include "task_data.h"
 #include "snapshot.h"
 
-void take_files_snapshot(struct task_data * data) {
+void take_files_snapshot(struct task_data *data) {
 
   struct files_struct *files = current->files;
   struct fdtable *     fdt = rcu_dereference_raw(files->fdt);
@@ -20,7 +20,7 @@ void take_files_snapshot(struct task_data * data) {
 
 }
 
-void recover_files_snapshot(struct task_data * data) {
+void recover_files_snapshot(struct task_data *data) {
 
   /*
    * assume the child process will not close any
@@ -73,7 +73,7 @@ void recover_files_snapshot(struct task_data * data) {
 
 }
 
-void clean_files_snapshot(struct task_data * data) {
+void clean_files_snapshot(struct task_data *data) {
 
   struct files_struct *files = current->files;
 
@@ -87,5 +87,4 @@ void clean_files_snapshot(struct task_data * data) {
   if (data->snapshot_open_fds != NULL) kfree(data->snapshot_open_fds);
 
 }
-
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -97,6 +97,7 @@ void recover_state(struct task_data *data) {
 
 void restore_snapshot(struct task_data* data) {
 
+  recover_threads_snapshot(data);
   recover_memory_snapshot(data);
   recover_files_snapshot(data);
   recover_state(data);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -11,9 +11,9 @@ void (*k_zap_page_range)(struct vm_area_struct *vma, unsigned long start,
                          unsigned long size);
 
 int exit_hook(struct kprobe *p, struct pt_regs *regs) {
-  
+
   clean_snapshot();
-  
+
   return 0;
 
 }
@@ -35,7 +35,7 @@ int snapshot_initialize_k_funcs() {
 
 }
 
-void initialize_snapshot(struct task_data * data, int config) {
+void initialize_snapshot(struct task_data *data, int config) {
 
   struct pt_regs *regs = task_pt_regs(current);
 
@@ -45,7 +45,7 @@ void initialize_snapshot(struct task_data * data, int config) {
 
     set_had_snapshot(data);
     hash_init(data->ss.ss_page);
-  
+
   }
 
   set_snapshot(data);
@@ -54,22 +54,22 @@ void initialize_snapshot(struct task_data * data, int config) {
 
   // copy current regs context
   data->ss.regs = *regs;
-  
+
   // copy current brk
   data->ss.oldbrk = current->mm->brk;
-  
+
 }
 
 int take_snapshot(int config) {
 
   struct task_data *data = ensure_task_data(current);
 
-  if (!have_snapshot(data)) { // first execution
+  if (!have_snapshot(data)) {  // first execution
 
     initialize_snapshot(data, config);
     take_memory_snapshot(data);
     take_files_snapshot(data);
-    
+
     return 1;
 
   }
@@ -86,16 +86,15 @@ void recover_state(struct task_data *data) {
 
     // restore regs context
     *regs = data->ss.regs;
-  
+
   }
-  
+
   // restore brk
-  if (current->mm->brk > data->ss.oldbrk)
-    current->mm->brk = data->ss.oldbrk;
+  if (current->mm->brk > data->ss.oldbrk) current->mm->brk = data->ss.oldbrk;
 
 }
 
-void restore_snapshot(struct task_data* data) {
+void restore_snapshot(struct task_data *data) {
 
   recover_threads_snapshot(data);
   recover_memory_snapshot(data);
@@ -121,8 +120,7 @@ int exit_snapshot(void) {
 
   }
 
-  if (data && had_snapshot(data))
-    clean_snapshot();
+  if (data && had_snapshot(data)) clean_snapshot();
 
   return 1;
 
@@ -140,3 +138,4 @@ void clean_snapshot(void) {
   remove_task_data(data);
 
 }
+

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -108,9 +108,7 @@ struct snapshot_vma {
 
 struct snapshot_thread {
 
-  struct task_struct* tsk;
-  
-  
+  struct task_struct *tsk;
 
 };
 
@@ -128,8 +126,8 @@ struct snapshot_page {
 
 };
 
-#define SNAPSHOT_PRIVATE  0x00000001
-#define SNAPSHOT_COW      0x00000002
+#define SNAPSHOT_PRIVATE 0x00000001
+#define SNAPSHOT_COW 0x00000002
 #define SNAPSHOT_NONE_PTE 0x00000010
 
 static inline bool is_snapshot_page_none_pte(struct snapshot_page *sp) {
@@ -175,8 +173,8 @@ struct snapshot {
   unsigned int  status;
   unsigned long oldbrk;
 
-  struct snapshot_vma * ss_mmap;
-  
+  struct snapshot_vma *ss_mmap;
+
   struct pt_regs regs;
 
   DECLARE_HASHTABLE(ss_page, SNAPSHOT_HASHTABLE_SZ);
@@ -185,24 +183,25 @@ struct snapshot {
 
 #define SNAPSHOT_NONE 0x00000000  // outside snapshot
 #define SNAPSHOT_MADE 0x00000001  // in snapshot
-#define SNAPSHOT_HAD  0x00000002  // once had snapshot
+#define SNAPSHOT_HAD 0x00000002   // once had snapshot
 
 extern void (*k_flush_tlb_mm_range)(struct mm_struct *mm, unsigned long start,
-                             unsigned long end, unsigned int stride_shift,
-                             bool freed_tables);
+                                    unsigned long end,
+                                    unsigned int  stride_shift,
+                                    bool          freed_tables);
 
 extern void (*k_zap_page_range)(struct vm_area_struct *vma, unsigned long start,
-                         unsigned long size);
+                                unsigned long size);
 
-void take_memory_snapshot(struct task_data * data);
+void take_memory_snapshot(struct task_data *data);
 void recover_memory_snapshot(struct task_data *data);
 void clean_memory_snapshot(struct task_data *data);
 
-void take_files_snapshot(struct task_data * data);
-void recover_files_snapshot(struct task_data * data);
-void clean_files_snapshot(struct task_data * data);
+void take_files_snapshot(struct task_data *data);
+void recover_files_snapshot(struct task_data *data);
+void clean_files_snapshot(struct task_data *data);
 
-void recover_threads_snapshot(struct task_data * data);
+void recover_threads_snapshot(struct task_data *data);
 
 int snapshot_initialize_k_funcs(void);
 
@@ -210,10 +209,10 @@ int wp_page_hook(struct kprobe *p, struct pt_regs *regs);
 int do_anonymous_hook(struct kprobe *p, struct pt_regs *regs);
 int exit_hook(struct kprobe *p, struct pt_regs *regs);
 
-int take_snapshot(int config);
+int  take_snapshot(int config);
 void recover_snapshot(void);
 void clean_snapshot(void);
-int exit_snapshot(void);
+int  exit_snapshot(void);
 
 void exclude_vmrange(unsigned long start, unsigned long end);
 void include_vmrange(unsigned long start, unsigned long end);

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -106,6 +106,14 @@ struct snapshot_vma {
 
 };
 
+struct snapshot_thread {
+
+  struct task_struct* tsk;
+  
+  
+
+};
+
 struct snapshot_page {
 
   unsigned long page_base;
@@ -193,6 +201,8 @@ void clean_memory_snapshot(struct task_data *data);
 void take_files_snapshot(struct task_data * data);
 void recover_files_snapshot(struct task_data * data);
 void clean_files_snapshot(struct task_data * data);
+
+void recover_threads_snapshot(struct task_data * data);
 
 int snapshot_initialize_k_funcs(void);
 

--- a/src/task_data.c
+++ b/src/task_data.c
@@ -6,8 +6,8 @@ static spinlock_t task_datas_lock;
 
 static void task_data_free_callback(struct rcu_head *rcu) {
 
-	struct task_data *data = container_of(rcu, struct task_data, rcu);
-	kfree(data);
+  struct task_data *data = container_of(rcu, struct task_data, rcu);
+  kfree(data);
 
 }
 
@@ -17,11 +17,16 @@ struct task_data *get_task_data(const struct task_struct *tsk) {
 
   rcu_read_lock();
   list_for_each_entry_rcu(data, &task_datas, list) {
+
     if (data->tsk == tsk) {
+
       rcu_read_unlock();
       return data;
+
     }
+
   }
+
   rcu_read_unlock();
 
   return NULL;
@@ -40,8 +45,8 @@ struct task_data *ensure_task_data(const struct task_struct *tsk) {
   data->tsk = tsk;
 
   spin_lock(&task_datas_lock);
-	list_add_rcu(&data->list, &task_datas);
-	spin_unlock(&task_datas_lock);
+  list_add_rcu(&data->list, &task_datas);
+  spin_unlock(&task_datas_lock);
 
   return data;
 
@@ -56,3 +61,4 @@ void remove_task_data(struct task_data *data) {
   call_rcu(&data->rcu, task_data_free_callback);
 
 }
+

--- a/src/task_data.h
+++ b/src/task_data.h
@@ -9,8 +9,8 @@ struct vmrange_node {
 
   unsigned long start;
   unsigned long end;
-  
-  struct vmrange_node* next;
+
+  struct vmrange_node *next;
 
 };
 
@@ -20,13 +20,13 @@ struct task_data {
   const struct task_struct *tsk;
 
   struct snapshot ss;
-  unsigned long *snapshot_open_fds;
-  
+  unsigned long * snapshot_open_fds;
+
   struct vmrange_node *allowlist, *blocklist;
-  int config;
+  int                  config;
 
   struct list_head list;
-  struct rcu_head rcu;
+  struct rcu_head  rcu;
 
 };
 
@@ -65,3 +65,4 @@ static inline bool had_snapshot(struct task_data *data) {
 }
 
 #endif
+

--- a/src/threads.c
+++ b/src/threads.c
@@ -3,40 +3,47 @@
 #include "task_data.h"
 #include "snapshot.h"
 
-static struct task_struct *next_tid(struct task_struct *start)
-{
-	struct task_struct *pos = NULL;
-	rcu_read_lock();
-	if (pid_alive(start)) {
-		pos = next_thread(start);
-		if (thread_group_leader(pos))
-			pos = NULL;
-		else
-			get_task_struct(pos);
-	}
-	rcu_read_unlock();
-	put_task_struct(start);
-	return pos;
+static struct task_struct *next_tid(struct task_struct *start) {
+
+  struct task_struct *pos = NULL;
+  rcu_read_lock();
+  if (pid_alive(start)) {
+
+    pos = next_thread(start);
+    if (thread_group_leader(pos))
+      pos = NULL;
+    else
+      get_task_struct(pos);
+
+  }
+
+  rcu_read_unlock();
+  put_task_struct(start);
+  return pos;
+
 }
 
 /* void take_threads_snapshot(struct task_data * data) {
 
   struct task_struct* t = get_task_struct(data->tsk->group_leader);
   while (t) {
+
     if (t != data->tsk)
       add_snapshot_thread(data, t);
     t = next_tid(t);
+
   }
 
 } */
 
-void recover_threads_snapshot(struct task_data * data) {
+void recover_threads_snapshot(struct task_data *data) {
 
-  struct task_struct* t = get_task_struct(data->tsk->group_leader);
+  struct task_struct *t = get_task_struct(data->tsk->group_leader);
   while (t) {
-    if (t != data->tsk)
-      send_sig(SIGKILL, t, 1);
+
+    if (t != data->tsk) send_sig(SIGKILL, t, 1);
     t = next_tid(t);
+
   }
 
 }
@@ -44,5 +51,4 @@ void recover_threads_snapshot(struct task_data * data) {
 /* void clean_thareds_snapshot(struct task_data * data) {
 
 } */
-
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -1,0 +1,48 @@
+#include "hook.h"
+#include "debug.h"
+#include "task_data.h"
+#include "snapshot.h"
+
+static struct task_struct *next_tid(struct task_struct *start)
+{
+	struct task_struct *pos = NULL;
+	rcu_read_lock();
+	if (pid_alive(start)) {
+		pos = next_thread(start);
+		if (thread_group_leader(pos))
+			pos = NULL;
+		else
+			get_task_struct(pos);
+	}
+	rcu_read_unlock();
+	put_task_struct(start);
+	return pos;
+}
+
+/* void take_threads_snapshot(struct task_data * data) {
+
+  struct task_struct* t = get_task_struct(data->tsk->group_leader);
+  while (t) {
+    if (t != data->tsk)
+      add_snapshot_thread(data, t);
+    t = next_tid(t);
+  }
+
+} */
+
+void recover_threads_snapshot(struct task_data * data) {
+
+  struct task_struct* t = get_task_struct(data->tsk->group_leader);
+  while (t) {
+    if (t != data->tsk)
+      send_sig(SIGKILL, t, 1);
+    t = next_tid(t);
+  }
+
+}
+
+/* void clean_thareds_snapshot(struct task_data * data) {
+
+} */
+
+


### PR DESCRIPTION
now we can fuzz multithreadeds apps that DOES NOT create threads before the snapshot, buf after. They are killed on restore.