### PR TITLE
Fix wrong define ARCH_HAS_SYSCALL_WRAPPER

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -129,7 +129,7 @@ static struct file_operations dev_fops = {
 
 };
 
-#ifdef ARCH_HAS_SYSCALL_WRAPPER
+#ifdef CONFIG_ARCH_HAS_SYSCALL_WRAPPER
 typedef int (*syscall_handler_t)(struct pt_regs *);
 
 // The original syscall handler that we removed to override exit_group()


### PR DESCRIPTION
Fixes #15

It seems like syscall wrappers were never taken into account. It usually worked because the argument is simply forwarded to the original syscall, but in some builds the pointer is truncated to an int, generating a read fault when accessed by the original exit syscall as we can see in #15 